### PR TITLE
ci: add CI workflow, make agentic PR verification mandatory

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,37 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  compile-check:
+    name: Python syntax check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+      - run: python -m py_compile firm_to_nds.py
+
+  sast:
+    name: SAST (Semgrep)
+    runs-on: ubuntu-latest
+    # Advisory: not currently blocking, to avoid turning main red on a still-evolving ruleset.
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - run: pip install semgrep
+      # Verified 0 findings locally against p/python.
+      - run: >-
+          semgrep scan --disable-version-check --metrics=off
+          --config p/python

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -48,6 +48,26 @@ python firm_to_nds.py [--dev] <input.firm> [output.nds]
 # --dev  → use header_dev.bin instead of header.bin
 ```
 
+## Agentic PR verification (MANDATORY on every PR)
+
+**Every PR MUST be verified end-to-end before merge, and the verdict MUST be posted as a PR
+comment** via `gh pr comment`. A headless agent (`claude -p`, local) drives the change and posts
+the result; it **never merges** — it waits for you. Running the pass and posting the verdict
+comment is **not optional**. It catches what a diff and a syntax check miss: a broken `--dev`
+flag, a wrong output path, a corrupted header/firm concatenation.
+
+- **Engine.** No browser, no server — this is a one-shot CLI. Verification means: run
+  `firm_to_nds.py` end-to-end against a **throwaway sample input**, e.g.
+  `dd if=/dev/urandom of=/tmp/sample.firm bs=1024 count=4` (or any small non-real dummy file),
+  then `python firm_to_nds.py /tmp/sample.firm /tmp/sample.nds` and confirm the output exists,
+  its size equals `header.bin` + input size, and its first bytes match `header.bin`; repeat with
+  `--dev` against `header_dev.bin`. Also check `-h`/no-args prints help and exits non-zero.
+  Never point it at real firmware dumps.
+- **Two layers.** Deterministic checks (`python -m py_compile`) stay the hard merge gate; the
+  agentic pass is advisory and never vetoes a merge on its own — but running it and posting the
+  verdict comment is mandatory.
+- **Hard limits.** The verdict awaits your close; the agent never merges.
+
 ## Working rules
 
 - **The header `.bin` files must ship with the script** — the tool reads them from its own


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/ci.yml`: **`python -m py_compile firm_to_nds.py`** (blocking syntax gate) and **Semgrep `p/python`** (advisory; verified 0 findings locally).
- Upgrades `CLAUDE.md` with a new **Agentic PR verification (MANDATORY on every PR)** section adapted to this single-script CLI: run `firm_to_nds.py` end-to-end against a throwaway sample `.firm` file (e.g. `dd if=/dev/urandom of=/tmp/sample.firm bs=1024 count=4`), confirm the output size equals `header.bin` + input size and its leading bytes match `header.bin`, repeat with `--dev`, and check the no-args/`-h` help path — never against real firmware dumps. Posting the verdict via `gh pr comment` is mandatory; the agent never merges.

## Test plan
- [ ] Open this PR's **Checks** tab: `compile-check` should be green; `sast` is advisory.
- [ ] Locally: `python -m py_compile firm_to_nds.py` → no output, exit 0.
- [ ] Locally: `pip install semgrep && semgrep scan --config p/python .` → expect 0 findings.
- [ ] Manually exercise the new verification recipe: `dd if=/dev/urandom of=/tmp/sample.firm bs=1024 count=4 && python firm_to_nds.py /tmp/sample.firm /tmp/sample.nds` → expect `OK: ... KB` and `sample.nds` size = `header.bin` size + 4096 bytes; then `python firm_to_nds.py` with no args → prints help, exits 1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)